### PR TITLE
Add Azure AD / workload identity authentication (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ php composer.phar require --prefer-dist sagacorp/yii2-queue-azure-service-bus
 or add the extension to your composer json.
 
 ```
-"sagacorp/yii2-queue-azure-service-bus": "~1.0.0"
+"sagacorp/yii2-queue-azure-service-bus": "^5.0"
 ```
 
 <h2>Basic Usage</h2>
@@ -37,22 +37,81 @@ return [
             'serviceBus' => [
                 'class' => \saga\queue\azure\service\ServiceBus::class,
 
-                // Optional
-                'connectionString' => 'Endpoint=sb://(namespace).servicebus.windows.net/(queue);SharedAccessKeyName=(sharedAccessKey);SharedAccessKey=(sharedAccessKeyName)',
+                // Where to connect. Either a connection string...
+                'connectionString' => 'Endpoint=sb://(namespace).servicebus.windows.net/;EntityPath=(queue)',
 
-                // value if not present in connectionString
+                // ...or the namespace and queue directly.
                 'namespace' => 'your service bus namespace',
-                'sharedAccessKey' => 'your shared access key to access the service bus queue',
-                'sharedAccessKeyName' => 'your shared access key name',
                 'queue' => 'the name of your Azure Service Bus queue (can be different than the name used as config key)',
+
+                // Required: how to authenticate (see below).
+                'tokenProvider' => [
+                    'class' => \saga\queue\azure\service\SasTokenProvider::class,
+                    'sharedAccessKeyName' => 'your shared access key name',
+                    'sharedAccessKey' => 'your shared access key',
+                ],
             ],
         ],
     ],
 ];
- ```       
-      
-*Currently this extension supports the [Shared Access Signature authentication](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas) only. It doesn't support Azure Active Directory.*
-        
+ ```
+
+<h3>Authentication</h3>
+
+Authentication is handled by a dedicated, **required** `tokenProvider` component, so the
+`ServiceBus` component itself only carries the connection parameters. The `tokenProvider` accepts a
+configuration array (as shown below), a shared application component id, or an already built
+`TokenProvider` instance. Two providers are shipped:
+
+**`SasTokenProvider`** — [Shared Access Signature](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas)
+authentication. Provide the key explicitly or derive it from a connection string:
+
+```php
+'tokenProvider' => [
+    'class' => \saga\queue\azure\service\SasTokenProvider::class,
+    'sharedAccessKeyName' => '...',
+    'sharedAccessKey' => '...',
+    // or, instead of the two keys above:
+    'connectionString' => 'Endpoint=;SharedAccessKeyName=...;SharedAccessKey=...',
+],
+```
+
+**`AzureAdTokenProvider`** — [Azure AD](https://learn.microsoft.com/azure/aks/workload-identity-overview)
+authentication via [`azure-oss/identity`](https://github.com/Azure-OSS/azure-identity-php)'s
+`DefaultAzureCredential` (environment variables, then workload identity). The acquired access token
+is used as a `Bearer` token against the Service Bus REST API. When the Azure Workload Identity
+mutating webhook is enabled, the credentials are injected automatically through the `AZURE_*`
+environment variables, so no configuration is needed:
+
+```php
+'tokenProvider' => \saga\queue\azure\service\AzureAdTokenProvider::class,
+```
+
+Optionally tune the scope and token caching:
+
+```php
+'tokenProvider' => [
+    'class' => \saga\queue\azure\service\AzureAdTokenProvider::class,
+    'scope' => 'https://servicebus.azure.net/.default', // default
+    // Shared token cache. Defaults to the application `cache` component when available, otherwise
+    // the token is only kept in memory for the lifetime of the worker. Set to false to opt out, or
+    // pass another cache component id / configuration / instance.
+    'cache' => 'cache',
+    'expiryLeeway' => 300, // seconds before expiry at which the cached token is refreshed
+],
+```
+
+> This provider requires a [PSR-18](https://www.php-fig.org/psr/psr-18/) HTTP client and
+> [PSR-17](https://www.php-fig.org/psr/psr-17/) factories to be installed, for example
+> `composer require guzzlehttp/guzzle`.
+
+The targeted identity must be granted a Service Bus data plane role (e.g. *Azure Service Bus Data
+Sender* / *Data Receiver*) on the namespace or queue.
+
+> **Upgrading from 4.x:** `tokenProvider` is now mandatory. Move the `sharedAccessKey`,
+> `sharedAccessKeyName` and `tokenDuration` options off `ServiceBus` and into a `SasTokenProvider`
+> under `tokenProvider` to keep the previous SAS behaviour.
+
 Once configured,  you can send a task into the queue:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   ],
   "require": {
     "php": "^8.3",
+    "azure-oss/identity": "^1.0",
     "nesbot/carbon": "^2.0 | ^3.0",
     "sagacorp/yii2-queue-contracts": "^1.0",
     "yiisoft/yii2-httpclient": "^2.0",
@@ -21,8 +22,12 @@
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",
+    "guzzlehttp/guzzle": "^7.10",
     "rector/rector": "^2.1",
     "laravel/pint": "^1.24"
+  },
+  "suggest": {
+    "guzzlehttp/guzzle": "Required by WorkloadIdentityTokenProvider: any PSR-18 HTTP client + PSR-17 factories (e.g. guzzlehttp/guzzle) to exchange the federated token for an Azure AD access token."
   },
   "autoload": {
     "psr-4": {
@@ -40,6 +45,7 @@
   "config": {
     "sort-packages": true,
     "allow-plugins": {
+      "php-http/discovery": true,
       "yiisoft/yii2-composer": true
     }
   }

--- a/src/service/AzureAdTokenProvider.php
+++ b/src/service/AzureAdTokenProvider.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace sagacorp\queue\azure\service;
+
+use AzureOss\Identity\AccessToken;
+use AzureOss\Identity\DefaultAzureCredential;
+use AzureOss\Identity\TokenCredential;
+use AzureOss\Identity\TokenRequestContext;
+use yii\base\Application;
+use yii\base\BaseObject;
+use yii\base\InvalidConfigException;
+use yii\caching\CacheInterface;
+use yii\caching\DummyCache;
+use yii\di\Instance;
+
+/**
+ * Authenticates against the Service Bus REST API with an Azure AD access token, delegating the
+ * token acquisition to azure-oss/identity's DefaultAzureCredential (environment variables, then
+ * workload identity).
+ *
+ * On AKS the federated token file and the client/tenant identifiers are injected automatically
+ * by the Azure Workload Identity mutating webhook through the AZURE_FEDERATED_TOKEN_FILE,
+ * AZURE_CLIENT_ID and AZURE_TENANT_ID environment variables, so this provider works without any
+ * explicit configuration.
+ *
+ * Requires a PSR-18 HTTP client and PSR-17 factories to be installed (e.g. guzzlehttp/guzzle).
+ *
+ * @see https://learn.microsoft.com/azure/aks/workload-identity-overview
+ */
+class AzureAdTokenProvider extends BaseObject implements TokenProvider
+{
+    /**
+     * The cache used to share acquired access tokens across requests/workers.
+     *
+     * Accepts a component id, a configuration array or a {@see CacheInterface} instance, and
+     * defaults to the application `cache` component when it is available. Set to `false` to disable
+     * shared caching and only keep the token in memory for the lifetime of the worker.
+     */
+    public array|CacheInterface|false|string $cache = 'cache';
+
+    /** Prefix for the cache key the access token is stored under. */
+    public string $cacheKeyPrefix = 'azure-service-bus.azure-ad-token';
+
+    /** Number of seconds before the real expiry at which the cached token is refreshed. */
+    public int $expiryLeeway = 300;
+
+    public string $scope = 'https://servicebus.azure.net/.default';
+
+    private AccessToken $accessToken;
+    private CacheInterface $cacheComponent;
+    private TokenCredential $credential;
+
+    public function getAuthorizationHeader(string $url): string
+    {
+        return 'Bearer ' . $this->getAccessToken();
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function init(): void
+    {
+        parent::init();
+
+        $this->credential = new DefaultAzureCredential();
+
+        $this->cacheComponent = $this->resolveCache();
+    }
+
+    protected function getAccessToken(): string
+    {
+        if (isset($this->accessToken) && $this->isFresh($this->accessToken)) {
+            return $this->accessToken->token;
+        }
+
+        $cacheKey = $this->cacheKey();
+
+        $cached = $this->cacheComponent->get($cacheKey);
+
+        if ($cached instanceof AccessToken && $this->isFresh($cached)) {
+            return ($this->accessToken = $cached)->token;
+        }
+
+        $this->accessToken = $this->credential->getToken(new TokenRequestContext([$this->scope]));
+
+        $ttl = $this->accessToken->expiresOn->getTimestamp() - time() - $this->expiryLeeway;
+
+        if ($ttl > 0) {
+            $this->cacheComponent->set($cacheKey, $this->accessToken, $ttl);
+        }
+
+        return $this->accessToken->token;
+    }
+
+    private function cacheKey(): string
+    {
+        return implode(':', [
+            $this->cacheKeyPrefix,
+            getenv('AZURE_TENANT_ID') ?: '',
+            getenv('AZURE_CLIENT_ID') ?: '',
+            $this->scope,
+        ]);
+    }
+
+    private function isFresh(AccessToken $token): bool
+    {
+        return time() < $token->expiresOn->getTimestamp() - $this->expiryLeeway;
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    private function resolveCache(): CacheInterface
+    {
+        if (false === $this->cache) {
+            return new DummyCache();
+        }
+
+        // Fall back to in-memory caching when the default `cache` component is not configured.
+        if ('cache' === $this->cache && (!\Yii::$app instanceof Application || !\Yii::$app->has('cache'))) {
+            return new DummyCache();
+        }
+
+        return Instance::ensure($this->cache, CacheInterface::class);
+    }
+}

--- a/src/service/ConnectionStringParser.php
+++ b/src/service/ConnectionStringParser.php
@@ -21,10 +21,8 @@ readonly class ConnectionStringParser
             $result[$key] = $value;
         }
 
-        foreach (['Endpoint', 'SharedAccessKeyName', 'SharedAccessKey'] as $required) {
-            if (!isset($result[$required])) {
-                throw new InvalidArgumentException("Missing {$required}");
-            }
+        if (!isset($result['Endpoint'])) {
+            throw new InvalidArgumentException('Missing Endpoint');
         }
 
         $parsed = parse_url($result['Endpoint']);

--- a/src/service/SasTokenProvider.php
+++ b/src/service/SasTokenProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace sagacorp\queue\azure\service;
+
+use yii\base\BaseObject;
+use yii\base\InvalidConfigException;
+
+class SasTokenProvider extends BaseObject implements TokenProvider
+{
+    public string $sharedAccessKey;
+    public string $sharedAccessKeyName;
+    public int $tokenDuration = 3600;
+
+    public function getAuthorizationHeader(string $url): string
+    {
+        return (new SasTokenGenerator($url, $this->sharedAccessKeyName, $this->sharedAccessKey, $this->tokenDuration))
+            ->generateSharedAccessSignatureToken();
+    }
+
+    /**
+     * @throws InvalidConfigException
+     */
+    public function init(): void
+    {
+        parent::init();
+
+        if (!isset($this->sharedAccessKey)) {
+            throw new InvalidConfigException('"sharedAccessKey" is required.');
+        }
+
+        if (!isset($this->sharedAccessKeyName)) {
+            throw new InvalidConfigException('"sharedAccessKeyName" is required.');
+        }
+    }
+}

--- a/src/service/ServiceBus.php
+++ b/src/service/ServiceBus.php
@@ -5,6 +5,7 @@ namespace sagacorp\queue\azure\service;
 use Carbon\Carbon;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
+use yii\di\Instance;
 use yii\helpers\ArrayHelper;
 use yii\httpclient\Client;
 use yii\httpclient\CurlTransport;
@@ -25,10 +26,16 @@ class ServiceBus extends Component
     public string $queue;
     public string $receiveMode = self::RECEIVE_MODE_PEEK_LOCK;
     public int $requestMaxRetries = 10;
-    public string $sharedAccessKey;
-    public string $sharedAccessKeyName;
     public string $to;
-    public int $tokenDuration = 3600;
+
+    /**
+     * The token provider used to authenticate requests against the Service Bus REST API.
+     *
+     * Accepts a component id, a configuration array or a {@see TokenProvider} instance.
+     * It is required: use a {@see SasTokenProvider} for Shared Access Signature authentication
+     * or an {@see AzureAdTokenProvider} for Azure AD (workload identity).
+     */
+    public array|string|TokenProvider $tokenProvider;
 
     private string $host;
     private Client $httpClient;
@@ -56,6 +63,9 @@ class ServiceBus extends Component
         $request->sendAndRetryOnFailure(['200']);
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     public function init(): void
     {
         parent::init();
@@ -64,12 +74,13 @@ class ServiceBus extends Component
             $connectionString = (new ConnectionStringParser($this->connectionString))->parseConnectionString();
 
             $this->host = $connectionString['host'];
-            $this->sharedAccessKeyName ??= $connectionString['SharedAccessKeyName'] ?? '';
-            $this->sharedAccessKey ??= $connectionString['SharedAccessKey'] ?? '';
             $this->queue ??= $connectionString['EntityPath'] ?? '';
         } else {
             $this->host = "{$this->namespace}.servicebus.windows.net";
         }
+
+        $this->tokenProvider = $this->resolveTokenProvider();
+
         $this->httpClient = new Client([
             'baseUrl' => sprintf('https://%s/%s', $this->host, $this->queue),
             'transport' => CurlTransport::class,
@@ -181,14 +192,24 @@ class ServiceBus extends Component
 
     protected function authorizationHeaderHandler(RequestEvent $requestEvent): void
     {
-        $authToken = (new SasTokenGenerator(
-            $requestEvent->request->getFullUrl(),
-            $this->sharedAccessKeyName,
-            $this->sharedAccessKey,
-            $this->tokenDuration
-        ))->generateSharedAccessSignatureToken();
+        $requestEvent->request->headers->set(
+            self::HEADER_AUTHENTICATION,
+            $this->tokenProvider->getAuthorizationHeader($requestEvent->request->getFullUrl()),
+        );
+    }
 
-        $requestEvent->request->headers->set(self::HEADER_AUTHENTICATION, $authToken);
+    /**
+     * @throws InvalidConfigException
+     */
+    protected function resolveTokenProvider(): TokenProvider
+    {
+        if (!isset($this->tokenProvider)) {
+            throw new InvalidConfigException(
+                'The "tokenProvider" property must be set to a TokenProvider.'
+            );
+        }
+
+        return Instance::ensure($this->tokenProvider, TokenProvider::class);
     }
 
     private function buildBatchEntry(Message $message): array

--- a/src/service/TokenProvider.php
+++ b/src/service/TokenProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace sagacorp\queue\azure\service;
+
+interface TokenProvider
+{
+    /**
+     * Build the value of the "Authorization" header for the given request URL.
+     *
+     * @param string $url the full URL of the request being authenticated
+     */
+    public function getAuthorizationHeader(string $url): string;
+}


### PR DESCRIPTION
## Summary

Introduces a pluggable `TokenProvider` abstraction for Service Bus authentication and makes it a **required** `ServiceBus` property. Adds **Azure AD / workload identity** support alongside the existing SAS auth.

⚠️ **Breaking change — targets v5.** `tokenProvider` is now mandatory and the SAS keys moved off `ServiceBus`.

## Changes

- **`TokenProvider` interface** with two implementations:
  - **`SasTokenProvider`** — Shared Access Signature (explicit keys or derived from a connection string).
  - **`AzureAdTokenProvider`** — Azure AD via [`azure-oss/identity`](https://github.com/Azure-OSS/azure-identity-php)'s `DefaultAzureCredential` (environment variables, then workload identity); the access token is used as a `Bearer` token against the REST API.
- **Token caching** in `AzureAdTokenProvider` through a configurable Yii cache component (defaults to the `cache` component when available, otherwise in-memory; set `false` to opt out), with an `expiryLeeway` refresh margin.
- **`ServiceBus`** no longer carries SAS keys; `connectionString` is used only for host/queue. `ConnectionStringParser` now requires only `Endpoint`.
- **Dependencies**: require `azure-oss/identity`; `guzzlehttp/guzzle` as a `suggest` + dev dependency (a PSR-18 client + PSR-17 factories are needed by `AzureAdTokenProvider`).
- **Docs**: README authentication section rewritten + 4.x → 5.0 upgrade notes.

## Upgrading from 4.x

Move `sharedAccessKey` / `sharedAccessKeyName` / `tokenDuration` off `ServiceBus` into a `SasTokenProvider` under `tokenProvider` to keep the previous SAS behaviour.
